### PR TITLE
Alternative for setting config on any external Notebook

### DIFF
--- a/segmind/__init__.py
+++ b/segmind/__init__.py
@@ -16,6 +16,7 @@ from .tracking import fluent
 from .utils.logging_utils import log_params_decorator  # noqa: F401
 from .utils.logging_utils import _configure_mlflow_loggers
 from .version import VERSION as __version__  # noqa: F401
+from segmind.lite_extensions.client_utils import get_user_info_with_new_token
 
 warnings.filterwarnings(
     'ignore', message='numpy.dtype size changed')  # noqa: E402
@@ -193,6 +194,16 @@ def set_runid(*args, **kwargs):
     return fluent.set_runid(*args, **kwargs)
 
 
+def config_nb(access_token):
+    try:
+        user_info = get_user_info_with_new_token(access_token=access_token)
+    except Exception as err:
+        print(f"Log-In failed !!! Error: {err}")
+        return
+
+    print(f"Welcome {user_info['username']}, Log-In Successful !!!")
+
+
 get_experiment = fluent.get_experiment
 # get_experiment_by_name = fluent.get_experiment_by_name
 get_tracking_uri = get_tracking_uri
@@ -209,5 +220,5 @@ get_tracking_uri = get_tracking_uri
 run = projects.run
 
 __all__ = [
-    'ActiveRun', 'run',
+    'ActiveRun', 'run', 'config_nb'
 ]

--- a/segmind/lite_extensions/client_utils.py
+++ b/segmind/lite_extensions/client_utils.py
@@ -134,10 +134,14 @@ def get_token():
             access_token = os.environ.get(_ACCESS_TOKEN)
         return access_token
 
-    config = get_secret_config()
-    email = config['secret']['email']
-    password = config['secret']['password']
-    return fetch_token(email, password)
+    raise ValueError(
+        f'Could not locate your credentials, Please use segmind.config_nb(access_token=...) to configure segmind.'
+    )
+
+    # config = get_secret_config()
+    # email = config['secret']['email']
+    # password = config['secret']['password']
+    # return fetch_token(email, password)
 
 
 def catch_mlflowlite_exception(func):

--- a/segmind/version.py
+++ b/segmind/version.py
@@ -1,3 +1,3 @@
 # Copyright 2022 Segmind Solutions Pvt Ltd.
 
-VERSION = "0.1.7"
+VERSION = "0.1.8-beta"


### PR DESCRIPTION
This is just like below, except it doesn't need to run on a "terminal", which sets env on a sub-shell
```python
!segmind config
```

We need to set the env within the python subprocess, hence:
```python
from segmind import config_nb

config_nb(token=...)
```
should set the config.

closes #17